### PR TITLE
add 'node' brew to install

### DIFF
--- a/install/brew.sh
+++ b/install/brew.sh
@@ -24,6 +24,7 @@ apps=(
   httpie
   imagemagick
   jq
+  node
   peco
   psgrep
   python


### PR DESCRIPTION
## Background

Add `node` to list of apps installed via homebrew.