### PR TITLE
add homebrew python to path

### DIFF
--- a/system/.path
+++ b/system/.path
@@ -14,6 +14,7 @@ prepend-path "/sbin"
 prepend-path "/usr/sbin"
 prepend-path "/usr/local/sbin"
 prepend-path "/usr/local/bin"
+prepend-path "/usr/local/opt/python/libexec/bin"
 
 # Remove duplicates (preserving prepended items)
 # Source: http://unix.stackexchange.com/a/40755


### PR DESCRIPTION
Background

Add homebrew python to path so `python` points to homebrew-python install executable.