### PR TITLE
Add shellcheck + bats tests with GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install test dependencies
+        run: brew install bats-core shellcheck pcre
+
+      - name: Run dot test (shellcheck + bats)
+        run: ./bin/dot test

--- a/bin/dot
+++ b/bin/dot
@@ -2,7 +2,6 @@
 
 BIN_NAME=$(basename "$0")
 COMMAND_NAME=$1
-SUB_COMMAND_NAME=$2
 
 sub_help () {
   echo "Usage: $BIN_NAME <command>"
@@ -38,13 +37,37 @@ sub_clean () {
 
 sub_macos () {
   for DEFAULTS_FILE in "${DOTFILES_DIR}"/macos/defaults*.sh; do
+    # shellcheck source=/dev/null
     echo "Applying ${DEFAULTS_FILE}" && . "${DEFAULTS_FILE}"
   done
   echo "Done. Some changes may require a logout/restart to take effect."
 }
 
 sub_dock () {
+  # shellcheck source=/dev/null
   . "${DOTFILES_DIR}/macos/dock.sh" && echo "Dock reloaded."
+}
+
+sub_test () {
+  if [ -z "$DOTFILES_DIR" ]; then
+    DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+  fi
+  cd "$DOTFILES_DIR" || return 1
+
+  if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "shellcheck not installed — run 'brew install shellcheck'" >&2
+    return 1
+  fi
+  if ! command -v bats >/dev/null 2>&1; then
+    echo "bats not installed — run 'brew install bats-core'" >&2
+    return 1
+  fi
+
+  echo "==> shellcheck"
+  shellcheck bin/* macos/*.sh osxdefaults.sh remote-install.sh || return 1
+  echo
+  echo "==> bats"
+  bats tests/ || return 1
 }
 
 case $COMMAND_NAME in
@@ -53,7 +76,7 @@ case $COMMAND_NAME in
     ;;
   *)
     shift
-    sub_${COMMAND_NAME} $@
+    sub_"${COMMAND_NAME}" "$@"
     if [ $? = 127 ]; then
       echo "'$COMMAND_NAME' is not a known command or has errors." >&2
       sub_help

--- a/bin/json
+++ b/bin/json
@@ -5,6 +5,7 @@ OPT_COLOR=""
 while getopts ":c" OPT; do
 	case "$OPT" in
 		c) OPT_COLOR="--color";;
+		*) ;;
 	esac
 done
 

--- a/macos/defaults.sh
+++ b/macos/defaults.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 COMPUTER_NAME="imiller"
 
 # Ask for the administrator password upfront

--- a/osxdefaults.sh
+++ b/osxdefaults.sh
@@ -1,10 +1,12 @@
+#!/usr/bin/env bash
+
 # Finder: show hidden files by default
 defaults write com.apple.finder AppleShowAllFiles -bool true
 # Automatically hide and show the Dock
 defaults write com.apple.dock autohide -bool true
 # Save screenshots to the desktop
-defaults write com.apple.screencapture location -string “$HOME/Desktop”
+defaults write com.apple.screencapture location -string "$HOME/Desktop"
 # Save screenshots in PNG format (other options: BMP, GIF, JPG, PDF, TIFF)
-defaults write com.apple.screencapture type -string “png”
+defaults write com.apple.screencapture type -string "png"
 # Disable the sound effects on boot
-sudo nvram SystemAudioVolume=” “
+sudo nvram SystemAudioVolume=" "

--- a/remote-install.sh
+++ b/remote-install.sh
@@ -3,7 +3,7 @@
 SOURCE="https://github.com/irmiller22/dotfiles"
 TARBALL="$SOURCE/tarball/master"
 TARGET="$HOME/.dotfiles"
-TAR_CMD="tar -xzv -C "$TARGET" --strip-components=1 --exclude='{.gitignore}'"
+TAR_CMD="tar -xzv -C \"$TARGET\" --strip-components=1 --exclude='{.gitignore}'"
 
 is_executable() {
   type "$1" > /dev/null 2>&1

--- a/tests/append.bats
+++ b/tests/append.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+setup() {
+  TMPFILE="$(mktemp)"
+}
+
+teardown() {
+  rm -f "$TMPFILE"
+}
+
+@test "append: adds a new line when not present" {
+  echo "existing line" > "$TMPFILE"
+  run append "new line" "$TMPFILE"
+  [ "$status" -eq 0 ]
+  grep -qx "new line" "$TMPFILE"
+}
+
+@test "append: is idempotent when the line is already present" {
+  echo "already here" > "$TMPFILE"
+  run append "already here" "$TMPFILE"
+  [ "$status" -eq 0 ]
+  [ "$(grep -cx "already here" "$TMPFILE")" -eq 1 ]
+}
+
+@test "append: running twice for the same new line keeps only one occurrence" {
+  echo "first" > "$TMPFILE"
+  run append "second" "$TMPFILE"
+  run append "second" "$TMPFILE"
+  [ "$status" -eq 0 ]
+  [ "$(grep -cx "second" "$TMPFILE")" -eq 1 ]
+}

--- a/tests/dot.bats
+++ b/tests/dot.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "dot: --help lists known commands" {
+  run dot --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"clean"* ]]
+  [[ "$output" == *"dock"* ]]
+  [[ "$output" == *"macos"* ]]
+  [[ "$output" == *"test"* ]]
+  [[ "$output" == *"update"* ]]
+}
+
+@test "dot: bare invocation shows help" {
+  run dot
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "dot: unknown subcommand exits 1 with error message" {
+  run dot definitely-not-a-real-subcommand
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"not a known command"* ]]
+}

--- a/tests/is-executable.bats
+++ b/tests/is-executable.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "is-executable: returns 0 for a known shell builtin / command (ls)" {
+  run is-executable ls
+  [ "$status" -eq 0 ]
+}
+
+@test "is-executable: returns 1 for a nonexistent command" {
+  run is-executable definitely-not-a-real-command-xyz123
+  [ "$status" -eq 1 ]
+}
+
+@test "is-executable: returns 1 when given no argument" {
+  run is-executable
+  [ "$status" -eq 1 ]
+}

--- a/tests/is-macos.bats
+++ b/tests/is-macos.bats
@@ -1,0 +1,11 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "is-macos: returns 0 when run on macOS" {
+  if [[ "$OSTYPE" != darwin* ]]; then
+    skip "not on macOS"
+  fi
+  run is-macos
+  [ "$status" -eq 0 ]
+}

--- a/tests/is-supported.bats
+++ b/tests/is-supported.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "is-supported: one-arg success exits 0" {
+  run is-supported "true"
+  [ "$status" -eq 0 ]
+}
+
+@test "is-supported: one-arg failure exits 1" {
+  run is-supported "false"
+  [ "$status" -eq 1 ]
+}
+
+@test "is-supported: three-arg success echoes the yes value" {
+  run is-supported "true" "yes" "no"
+  [ "$status" -eq 0 ]
+  [ "$output" = "yes" ]
+}
+
+@test "is-supported: three-arg failure echoes the no value" {
+  run is-supported "false" "yes" "no"
+  [ "$status" -eq 0 ]
+  [ "$output" = "no" ]
+}

--- a/tests/plistbuddy.bats
+++ b/tests/plistbuddy.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load test_helper
+
+@test "plistbuddy: silently no-ops when the target plist does not exist" {
+  run plistbuddy com.example.no-such-plist-xyz123 Print :NonExistent
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "plistbuddy: reads a key from an existing plist" {
+  TMPHOME="$(mktemp -d)"
+  mkdir -p "$TMPHOME/Library/Preferences"
+  PLIST_PATH="$TMPHOME/Library/Preferences/com.example.test.plist"
+  /usr/libexec/PlistBuddy -c "Add :TestKey string TestValue" "$PLIST_PATH" >/dev/null
+
+  HOME="$TMPHOME" run plistbuddy com.example.test Print :TestKey
+  rm -rf "$TMPHOME"
+
+  [ "$status" -eq 0 ]
+  [ "$output" = "TestValue" ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Common setup for bats tests — load via `load test_helper` in *.bats files.
+
+DOTFILES_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+export DOTFILES_DIR
+export PATH="$DOTFILES_DIR/bin:$PATH"


### PR DESCRIPTION
## Summary

Set up CI-runnable tests for the dotfiles repo. Three pieces:

- **shellcheck** (already in Brewfile) runs against `bin/*`, `macos/*.sh`, `osxdefaults.sh`, and `remote-install.sh`.
- **bats** (already in Brewfile as `bats-core`) runs unit tests for the `bin/` helpers — **16 tests** covering happy + sad paths for `append`, `is-executable`, `is-macos`, `is-supported`, `plistbuddy`, and the `dot` CLI dispatch.
- **`dot test`** subcommand is now wired up — it was listed in `dot --help` but the `sub_test` function was never defined. Now runs both shellcheck and bats.
- **GitHub Actions** workflow at `.github/workflows/test.yml` runs `./bin/dot test` on every push to `master` and every PR (macos-latest runner, installs `bats-core`, `shellcheck`, `pcre`).

## Lint findings fixed (so CI is green)

shellcheck surfaced a few real issues; mechanical fixes included:

- **`osxdefaults.sh`** had Unicode smart quotes (`"` and `"`) instead of straight quotes — meaning the `defaults write … -string` commands were storing the literal string `"$HOME/Desktop"` (unexpanded) as the screencapture location. Real runtime bug.
- **`remote-install.sh:6`** had broken nested quoting on `$TARGET` inside the `TAR_CMD` string.
- **`bin/dot:56`** didn't quote `$@` on the dynamic dispatch line; also had an unused `SUB_COMMAND_NAME` variable.
- **`bin/json`** getopts loop had no default case.
- **`macos/defaults.sh`** and **`osxdefaults.sh`** were missing shebangs / shell directives.

## Not in scope (follow-ups)

- **`macos/defaults.sh:1`** still hardcodes `COMPUTER_NAME="imiller"` — same class of bug as the `.zprofile` `imiller` hardcode. Belongs with the canonical-path tickets (LAT-25).
- **`bin/json`** depends on `underscore-cli` which we removed from `npmfile` in the curation PR. The script is currently broken at runtime but isn't referenced from anywhere in the repo. No bats test written for it. Decide later: delete or rewrite to use `jq`.
- **Integration smoke test for `make link`** — separate LAT-31 ticket, different layer.

## Test plan

- [x] `bin/dot test` passes locally — 16/16 bats, shellcheck clean
- [ ] GitHub Actions run on this PR turns green
- [ ] Future regressions (introduce a shellcheck error in `bin/*`) caught by CI