### PR TITLE
Enforce ~/.dotfiles canonical path; drop bash install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
-SHELL = /bin/bash
+SHELL = /bin/sh
 DOTFILES_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 OS := $(shell bin/is-supported bin/is-macos macos linux)
 PATH := $(DOTFILES_DIR)/bin:$(PATH)
 export XDG_CONFIG_HOME = $(HOME)/.config
 export STOW_DIR = $(DOTFILES_DIR)
 export ACCEPT_EULA=Y
+
+# Enforce canonical install location. CI checks out to a non-canonical path,
+# so the guard is bypassed there.
+ifndef GITHUB_ACTION
+ifneq ($(DOTFILES_DIR),$(HOME)/.dotfiles)
+$(error Dotfiles must be installed at $$HOME/.dotfiles, found $(DOTFILES_DIR). See README.)
+endif
+endif
 
 .PHONY: test
 
@@ -14,7 +22,7 @@ macos: sudo core-macos packages link
 
 linux: core-linux link
 
-core-macos: brew bash git ruby
+core-macos: brew git ruby
 
 core-linux:
 	apt-get update
@@ -44,23 +52,6 @@ unlink: stow-$(OS)
 
 brew:
 	is-executable brew || curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh | bash
-
-bash: BASH=/usr/local/bin/bash
-bash: SHELLS=/private/etc/shells
-bash: brew
-ifdef GITHUB_ACTION
-	if ! grep -q $(BASH) $(SHELLS); then \
-		brew install bash bash-completion@2 pcre && \
-		sudo append $(BASH) $(SHELLS) && \
-		sudo chsh -s $(BASH); \
-	fi
-else
-	if ! grep -q $(BASH) $(SHELLS); then \
-		brew install bash bash-completion@2 pcre && \
-		sudo append $(BASH) $(SHELLS) && \
-		chsh -s $(BASH); \
-	fi
-endif
 
 git: brew
 	brew install git git-extras

--- a/README.md
+++ b/README.md
@@ -9,22 +9,28 @@ On a sparkling fresh installation of OS X:
     sudo softwareupdate -i -a
     xcode-select --install
 
-Install the dotfiles with either Git or curl:
+Install the dotfiles with either Git or curl. The repo **must** live at
+`~/.dotfiles` — the Makefile enforces this and the install scripts
+assume it.
 
 ### Clone with Git
 
-    git clone https://github.com/irmiller22/dotfiles.git
-    source dotfiles/install.sh
+    git clone https://github.com/irmiller22/dotfiles.git ~/.dotfiles
+    cd ~/.dotfiles
+    make all
 
 ### Remotely install using curl
 
-Alternatively, you can install this into `~/.dotfiles` remotely without Git using curl:
+Alternatively, you can install this into `~/.dotfiles` remotely without
+Git using curl, then run `make` from the resulting directory:
 
-    sh -c "`curl -fsSL https://raw.github.com/irmiller22/dotfiles/master/remote-install.sh`"
+    sh -c "`curl -fsSL https://raw.githubusercontent.com/irmiller22/dotfiles/master/remote-install.sh`"
+    cd ~/.dotfiles && make all
 
 Or, using wget:
 
     sh -c "`wget -O - --no-check-certificate https://raw.githubusercontent.com/irmiller22/dotfiles/master/remote-install.sh`"
+    cd ~/.dotfiles && make all
 
 ## The `dotfiles` command
 


### PR DESCRIPTION
## Summary

Implements two related Makefile-cleanup tickets:

### LAT-25 — canonical install path

- **Makefile guard**: errors out if `$(DOTFILES_DIR) != $HOME/.dotfiles`. Bypassed when `$GITHUB_ACTION` is set so CI runners (which check out to `/Users/runner/work/dotfiles/dotfiles`) aren't blocked.
- **README**: clone instructions now specify `~/.dotfiles` explicitly and call `make all` (replaces the stale `install.sh` reference — that file never existed).

### LAT-26 — drop bash install target

PR #12 moved the runcom from bash to zsh, but the `bash:` Makefile target still installed Homebrew bash, appended it to `/etc/shells`, and `chsh -s`'d to it. On a fresh install this would flip the login shell back to bash. Fixed by:

- Delete the entire `bash:` target (~16 lines)
- Drop `bash` dependency from `core-macos: brew git ruby` (was: `brew bash git ruby`)
- Change `SHELL = /bin/bash` → `/bin/sh` at top of Makefile (recipes are POSIX-compatible — verified)

zsh is the default login shell on macOS Catalina+ so no replacement target is needed.

## Sanity checks

- [x] `make -n link` parses cleanly from canonical path
- [x] Guard fires with helpful message: `Makefile:13: *** Dotfiles must be installed at $HOME/.dotfiles, found /tmp/wrong. See README..  Stop.`
- [x] `GITHUB_ACTION=test make -n ...` bypasses the guard
- [x] `bin/dot test` — 16/16 bats pass, shellcheck clean