### PR TITLE
De-personalize macos/defaults.sh (LAT-34)

### DIFF
--- a/macos/defaults.sh
+++ b/macos/defaults.sh
@@ -1,6 +1,6 @@
 # shellcheck shell=bash
 
-COMPUTER_NAME="imiller"
+COMPUTER_NAME="${COMPUTER_NAME:-$USER}"
 
 # Ask for the administrator password upfront
 sudo -v
@@ -126,15 +126,13 @@ defaults write com.apple.BezelServices kDim -bool true
 defaults write com.apple.BezelServices kDimTime -int 300
 
 # Set language and text formats
-# Note: if you’re in the US, replace `EUR` with `USD`, `Centimeters` with
-# `Inches`, `en_GB` with `en_US`, and `true` with `false`.
-defaults write NSGlobalDomain AppleLanguages -array "en" "nl"
-defaults write NSGlobalDomain AppleLocale -string "en_US@currency=EUR"
-defaults write NSGlobalDomain AppleMeasurementUnits -string "Centimeters"
-defaults write NSGlobalDomain AppleMetricUnits -bool true
+defaults write NSGlobalDomain AppleLanguages -array "en"
+defaults write NSGlobalDomain AppleLocale -string "en_US@currency=USD"
+defaults write NSGlobalDomain AppleMeasurementUnits -string "Inches"
+defaults write NSGlobalDomain AppleMetricUnits -bool false
 
 # Set the timezone; see `sudo systemsetup -listtimezones` for other values
-sudo systemsetup -settimezone "Europe/Amsterdam" > /dev/null
+sudo systemsetup -settimezone "America/New_York" > /dev/null
 
 # Disable auto-correct
 defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false


### PR DESCRIPTION
## Summary

Implements [LAT-34](https://linear.app/lattice-software/issue/LAT-34): replace inherited-template personalization values in `macos/defaults.sh` that didn't match this user.

## Changes

| Setting | Old | New | Rationale |
|---|---|---|---|
| `COMPUTER_NAME` | `"imiller"` | `"${COMPUTER_NAME:-$USER}"` | Wrong username (this user is `irmiller22`); env-overridable default |
| `AppleLanguages` | `["en", "nl"]` | `["en"]` | Dutch was a template leftover, user is English-only |
| `AppleLocale` currency | `EUR` | `USD` | US-based user |
| `AppleMeasurementUnits` | `Centimeters` | `Inches` | US imperial |
| `AppleMetricUnits` | `true` | `false` | Match imperial units |
| `systemsetup -settimezone` | `Europe/Amsterdam` | `America/New_York` | US East Coast based |
| Comment at lines 129-130 | "if you're in the US, replace EUR with USD…" | (removed) | Now obsolete since file *is* US-configured |

## Not changed

Intentionally left alone:
- Trackpad sensitivity / scroll direction (subjective)
- Dock orientation, autohide settings (subjective)
- Finder display preferences (subjective)
- Hot corner assignments (subjective)
- Anything else that's a preference rather than a locale/identity hardcode

## Test plan

- [x] `bin/dot test` passes (16/16 bats, shellcheck clean)
- [ ] CI run on this PR is green
- [ ] On next `dot macos` run, the computer name follows `$USER` and the locale is US-standard

## Related

- LAT-25 fixed a similar `imiller` hardcode in `runcom/.zprofile` (which has since been deleted as part of LAT-32)
- This was spun out from LAT-33 (shellcheck + bats CI) which surfaced the `COMPUTER_NAME` line during the audit