### PR TITLE
Add make-link smoke-test job to CI (LAT-31)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,3 +16,51 @@ jobs:
 
       - name: Run dot test (shellcheck + bats)
         run: ./bin/dot test
+
+  link-smoke-test:
+    name: make link smoke test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install stow
+        run: brew install stow
+
+      - name: Run make link
+        run: make link
+
+      - name: Verify XDG symlinks point into the repo
+        env:
+          REPO_DIR: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          fail=0
+          assert_link() {
+            local link="$1" want="$2"
+            if [ ! -L "$link" ]; then
+              echo "FAIL: $link is not a symlink" >&2; fail=1; return
+            fi
+            local got want_abs
+            got="$(cd -P "$link" && pwd -P)"
+            want_abs="$(cd -P "$want" && pwd -P)"
+            if [ "$got" != "$want_abs" ]; then
+              echo "FAIL: $link -> $got (expected $want_abs)" >&2; fail=1
+            else
+              echo "OK:   $link -> $got"
+            fi
+          }
+          assert_link "$HOME/.config/git"      "$REPO_DIR/config/git"
+          assert_link "$HOME/.config/prettier" "$REPO_DIR/config/prettier"
+          exit "$fail"
+
+      - name: Re-run make link (idempotency check)
+        run: make link
+
+      - name: Assert no hardcoded /Users/<name> paths in Makefile
+        run: |
+          set -euo pipefail
+          if grep -nE '/Users/[A-Za-z0-9_.-]+' Makefile; then
+            echo "FAIL: hardcoded /Users/<name> path found in Makefile" >&2
+            exit 1
+          fi
+          echo "OK: no hardcoded user paths in Makefile"


### PR DESCRIPTION
## Summary

Adds a second CI job that runs `make link` on a macOS runner and asserts the expected symlinks. Implements [LAT-31](https://linear.app/lattice-software/issue/LAT-31).

## What it catches

- `make link` actually completes successfully on a fresh runner
- `$HOME/.config/git` symlinks into `config/git`
- `$HOME/.config/prettier` symlinks into `config/prettier`
- `make link` is **idempotent** (running it twice doesn't error)
- **Regression guard**: no hardcoded `/Users/<name>` paths in the Makefile (covers the class of bug like the deleted `imiller` hardcode)

## Why it works in CI

The Makefile's canonical-path guard from LAT-25 (`$(DOTFILES_DIR) == $HOME/.dotfiles`) is bypassed when `$GITHUB_ACTION` is set, so the non-canonical runner checkout path (`/Users/runner/work/dotfiles/dotfiles`) doesn't block.

## Trigger semantics

Because the new job lives in the existing `.github/workflows/test.yml` and the workflow triggers on `pull_request:`, this new job **runs on this PR itself** — we'll see if the smoke test catches anything before merge.

## What was skipped

- The optional `make all` job (full Brewfile install) — 10+ minute runtime, expensive in CI minutes for marginal value over the targeted smoke test. Can be added later as a `workflow_dispatch` manual job if needed.

## Test plan

- [x] YAML parses (ruby yaml)
- [x] `bin/dot test` still passes locally
- [ ] **The new `link-smoke-test` job runs on this PR and passes**