### PR TITLE
Add CLAUDE.md and per-directory READMEs (LAT-30)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+Orientation for Claude Code sessions working in this repo.
+
+## What this repo is
+
+Personal dotfiles for `irmiller22`. Two layers:
+
+1. **System config** (`config/`, `macos/`) — versioned, declarative, applied via `make`
+2. **Tooling manifests** (`install/`, `bin/`) — what should be installed on a fresh machine, plus helper CLIs
+
+Shell init (`~/.zshrc`, `~/.zprofile`) is **NOT** in this repo — it is hand-maintained per machine. The `runcom/` and `system/` directories were deleted on purpose (LAT-32). Do not suggest adding them back.
+
+## Canonical install location
+
+The repo **must** live at `~/.dotfiles`. The `Makefile` has a guard that errors out if `$(DOTFILES_DIR) != $HOME/.dotfiles`. The guard is bypassed when `$GITHUB_ACTION` is set so CI runs work.
+
+If you spawn a sub-agent in a worktree (which lives at a different path), do not run `make` from there — it will refuse. Use direct file editing instead.
+
+## Install flow
+
+| Command | What it does |
+| --- | --- |
+| `make all` | Full install: Homebrew, Brewfile, Caskfile, then `make link` |
+| `make link` | Stow `config/` → `$XDG_CONFIG_HOME` (typically `~/.config`) |
+| `make unlink` | Reverse of `make link` |
+| `make brew-packages` | Install/update from `install/Brewfile` |
+| `make cask-apps` | Install/update from `install/Caskfile` (and VSCode extensions) |
+
+The README (and earlier templates) referred to an `install.sh` — that file never existed. The Makefile is the only entry point.
+
+## Directories
+
+- **`bin/`** — Helper scripts (`is-executable`, `is-macos`, `is-supported`, `append`, `plistbuddy`) and the `dot` CLI. Anything Makefile recipes need lives here.
+- **`config/`** — Stowed to `$XDG_CONFIG_HOME`. Currently `config/git/` and `config/prettier/`.
+- **`install/`** — Prescriptive install manifests (see "Install manifests are prescriptive" below).
+- **`macos/`** — `defaults.sh` (~448 lines of `defaults write …` commands) and `dock.sh`. Applied via `dot macos` and `dot dock`.
+- **`tests/`** — `bats` tests for the `bin/` helpers and the `dot` CLI.
+- **`.github/workflows/`** — CI: shellcheck + bats job, plus a `make link` smoke-test job.
+
+## Install manifests are prescriptive
+
+`install/Brewfile`, `install/Caskfile`, `install/Gemfile`, `install/npmfile` declare what **should** be installed on a fresh machine — not what currently is. When the live machine and a manifest diverge, the question is **per-tool curation**: "if I rebuilt this machine tomorrow, do I want this installed?"
+
+Don't shrink the manifests just because the current machine doesn't have something. Don't pad them with one-off tools that aren't worth re-installing.
+
+## Testing
+
+```sh
+bin/dot test
+```
+
+Runs `shellcheck` on `bin/*`, `macos/*.sh`, `osxdefaults.sh`, `remote-install.sh`, then `bats` on `tests/*.bats`. CI runs the same command on every push to `master` and every PR.
+
+If you add or modify a `bin/` script, shellcheck must pass. If you add user-facing behavior, add a bats test.
+
+## Workflow conventions
+
+- **Never** commit directly to `master` and push. Always:
+  1. Branch from `master` with a descriptive kebab-case name
+  2. Commit with HEREDOC messages ending with the standard `Co-Authored-By: Claude …` trailer
+  3. Push the branch
+  4. `gh pr create --base master …`
+  5. Merge only when CI is green and the user approves
+- Linear ticket IDs (`LAT-NN`) are referenced from commit messages and PR descriptions when applicable.
+- Background agents in worktrees currently can't perform mutating operations — if delegating implementation, expect to take over the actual edits/commits from the main session.
+
+## Things that look like bugs but are intentional
+
+- `~/.zshrc` is a regular file (not a symlink). Per-machine shell init is hand-maintained.
+- `config/git` and `config/prettier` are the only items under `config/`. That's the entire stow scope.
+- Some `install/` manifests list tools that aren't installed on the current machine. They're prescriptive; that's expected.

--- a/README.md
+++ b/README.md
@@ -32,19 +32,21 @@ Or, using wget:
     sh -c "`wget -O - --no-check-certificate https://raw.githubusercontent.com/irmiller22/dotfiles/master/remote-install.sh`"
     cd ~/.dotfiles && make all
 
-## The `dotfiles` command
+## The `dot` command
 
-    $ dotfiles help
-    Usage: dotfiles <command>
+    $ dot help
+    Usage: dot <command>
 
     Commands:
+       clean            Clean up caches (brew, gem)
+       dock             Apply macOS Dock settings
+       edit             Open dotfiles in IDE ($DOTFILES_IDE) and Git GUI ($DOTFILES_GIT_GUI)
        help             This help message
-       edit             Open dotfiles in editor ($EDITOR_ALT) and Git GUI ($GIT_GUI)
-       reload           Reload dotfiles
-       update           Update packages and pkg managers (OS, brew, gem, pip)
-       clean            Clean up caches (brew, gem, rvm)
-       osx              Apply OS X system defaults
-       dock             Apply OS X Dock settings
+       macos            Apply macOS system defaults
+       test             Run shellcheck and bats tests
+       update           Update packages and pkg managers (OS, brew, gem)
+
+See [`bin/README.md`](./bin/README.md) for the helper scripts that back the CLI, and [`CLAUDE.md`](./CLAUDE.md) for the repo's conventions and constraints.
 
 ## Additional resources
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,30 @@
+# bin/
+
+Helper scripts plus the `dot` CLI. Everything here is added to `$PATH` by the Makefile (`PATH := $(DOTFILES_DIR)/bin:$(PATH)`) so Makefile recipes can invoke these scripts without absolute paths.
+
+## Helpers
+
+| Script | Purpose |
+| --- | --- |
+| `is-executable <cmd>` | Exit 0 if `cmd` is on `$PATH`, else 1 |
+| `is-macos` | Exit 0 on macOS (checks `$OSTYPE`) |
+| `is-supported <test> [yes] [no]` | Eval `test`; with 1 arg, exit 0/1; with 3 args, echo `yes` or `no` |
+| `append <line> <file>` | Append `line` to `file` if not already present (idempotent via `pcregrep -M`) |
+| `plistbuddy <plist> <action> <key> [value]` | Wrapper around `/usr/libexec/PlistBuddy` against `~/Library/Preferences/<plist>.plist` |
+
+## The `dot` CLI
+
+`dot help` for the surface. Subcommands:
+
+| Subcommand | Action |
+| --- | --- |
+| `dot clean` | `brew cleanup`, `gem cleanup` |
+| `dot dock` | Apply `macos/dock.sh` |
+| `dot edit` | Open the dotfiles in `$DOTFILES_IDE` and `$DOTFILES_GIT_GUI` |
+| `dot macos` | Source every `macos/defaults*.sh` |
+| `dot test` | Run `shellcheck` on tracked scripts then `bats` on `tests/` |
+| `dot update` | `softwareupdate -i -a`, `brew update`/`upgrade`/`cleanup`, `gem update --system`, `gem update` |
+
+`dot` resolves the dotfiles directory via `$DOTFILES_DIR` (set by the user's shell init) or falls back to `dirname "$(dirname "$0")"`.
+
+Each `bin/*` script has a corresponding `tests/*.bats` file (except `dot` whose tests cover dispatch + help).

--- a/bin/dot
+++ b/bin/dot
@@ -64,7 +64,9 @@ sub_test () {
   fi
 
   echo "==> shellcheck"
-  shellcheck bin/* macos/*.sh osxdefaults.sh remote-install.sh || return 1
+  # Exclude non-script files (e.g. README.md) from the bin/ glob
+  # shellcheck disable=SC2046  # word-splitting is intentional here
+  shellcheck $(find bin -type f ! -name "*.md") macos/*.sh osxdefaults.sh remote-install.sh || return 1
   echo
   echo "==> bats"
   bats tests/ || return 1

--- a/install/README.md
+++ b/install/README.md
@@ -1,0 +1,19 @@
+# install/
+
+Prescriptive manifests for what should be installed on a fresh machine. Each file is consumed by a corresponding `make` target:
+
+| File | Consumer | Purpose |
+| --- | --- | --- |
+| `Brewfile` | `make brew-packages` (via `brew bundle`) | Homebrew formulae |
+| `Brewfile.lock.json` | (auto-managed by `brew bundle`) | Lockfile |
+| `Caskfile` | `make cask-apps` (via `brew bundle`) | Homebrew casks (GUI apps) |
+| `Gemfile` | (currently unused) | Ruby gems |
+| `npmfile` | (no make target yet) | Global npm packages |
+
+## These are prescriptive, not descriptive
+
+When the live machine and a manifest diverge, the question is **per-tool curation**: "if I rebuilt this machine tomorrow, do I want this installed?" Don't shrink the manifests just because the current machine doesn't have something, and don't pad them with one-off tools that aren't worth re-installing.
+
+## Known stale references
+
+`Makefile`'s `cask-apps` target also reads `install/Codefile` (for VSCode extensions) — but that file no longer exists. The line is dead and needs to be either removed or `Codefile` needs to be re-created. Tracked separately from these docs.


### PR DESCRIPTION
## Summary

Implements [LAT-30](https://linear.app/lattice-software/issue/LAT-30): add repo orientation docs for future Claude Code sessions and human contributors.

## Files added

- **`CLAUDE.md`** — repo root orientation. Canonical `~/.dotfiles` install location + Makefile guard, install flow (Makefile is the entrypoint, `install.sh` never existed), directory roles, prescriptive manifests, hand-maintained shell init, testing, PR workflow.
- **`install/README.md`** — manifests are prescriptive (don't shrink to match what's installed). Also flags the stale `Codefile` reference in Makefile.
- **`bin/README.md`** — helper scripts + `dot` CLI overview.

## Files changed

- **`README.md`** — fixed the stale "## The `dotfiles` command" section. It documented an old command name and wrong subcommands (`reload`, `osx`). Now shows the actual `dot` CLI surface and links to `bin/README.md` + `CLAUDE.md`.
- **`bin/dot`** — the shellcheck target glob in `sub_test` now excludes `*.md` files via `find`, so the new `bin/README.md` doesn't break CI. One-line change with a `shellcheck disable=SC2046` comment explaining the intentional word-splitting.

## Surfaced (not fixed here)

The LAT-30 agent found that `install/Codefile` is referenced in `Makefile:68` (`cat install/Codefile`) but the file doesn't exist. This would break a fresh `make cask-apps` install. Worth a separate ticket — flagged in `install/README.md`.

## Test plan

- [x] `bin/dot test` passes locally — 16/16 bats, shellcheck clean after the `find`-based glob
- [ ] CI is green on this PR