### PR TITLE
Recreate install/Codefile for VSCode extensions

### DIFF
--- a/install/Codefile
+++ b/install/Codefile
@@ -1,0 +1,1 @@
+anthropic.claude-code

--- a/install/README.md
+++ b/install/README.md
@@ -7,13 +7,10 @@ Prescriptive manifests for what should be installed on a fresh machine. Each fil
 | `Brewfile` | `make brew-packages` (via `brew bundle`) | Homebrew formulae |
 | `Brewfile.lock.json` | (auto-managed by `brew bundle`) | Lockfile |
 | `Caskfile` | `make cask-apps` (via `brew bundle`) | Homebrew casks (GUI apps) |
+| `Codefile` | `make cask-apps` (via `code --install-extension`) | VSCode extensions |
 | `Gemfile` | (currently unused) | Ruby gems |
 | `npmfile` | (no make target yet) | Global npm packages |
 
 ## These are prescriptive, not descriptive
 
 When the live machine and a manifest diverge, the question is **per-tool curation**: "if I rebuilt this machine tomorrow, do I want this installed?" Don't shrink the manifests just because the current machine doesn't have something, and don't pad them with one-off tools that aren't worth re-installing.
-
-## Known stale references
-
-`Makefile`'s `cask-apps` target also reads `install/Codefile` (for VSCode extensions) — but that file no longer exists. The line is dead and needs to be either removed or `Codefile` needs to be re-created. Tracked separately from these docs.


### PR DESCRIPTION
## Summary
- Recreate `install/Codefile` with `anthropic.claude-code` so the dead Makefile reference (`cask-apps` line 68) resolves.
- Curated per the prescriptive-manifest convention — the current machine also has `github.copilot-chat`, but it was excluded as not worth re-installing on a fresh box.
- Drop the "Known stale references" section from `install/README.md` and add Codefile to the manifest table.

## Test plan
- [x] CI green (shellcheck + bats + make-link smoke test)
- [x] `make cask-apps` no longer errors on the `cat install/Codefile` step

Refs LAT-36.