### PR TITLE
Add .gitignore for Claude Code local artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Claude Code local artifacts — machine-local, never committed
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## What

Adds a `.gitignore` (the repo had none) covering machine-local Claude Code artifacts:

- `.claude/settings.local.json`
- `.claude/worktrees/`

## Why

These are per-machine scratch files that were sitting untracked and could be accidentally committed. Scoped to specific paths rather than ignoring all of `.claude/`, so shared config (skills, commands, a non-local `settings.json`) can still be versioned later if desired.

## Housekeeping done alongside (local only, not in this PR)

- Pruned 4 stale, locked agent worktrees (the locking process was dead) and their merged `worktree-agent-*` branches.
- Deleted two fully-merged local branches (`docs-claude-md-and-readmes` → #21, `fix-codefile-reference` → #22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)